### PR TITLE
Fix location of `verify_peer` check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,3 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: bundle exec rake spec
-  spec-legacy:
-    name: "RSpec / Ruby 2.2"
-    runs-on: ubuntu-20.04
-    steps:
-      - run: sudo apt-get install libcurl4-openssl-dev
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.2
-          bundler-cache: true
-      - name: rake spec
-        run: bundle exec rake spec

--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -94,6 +94,16 @@ module EventMachine
       end
 
       def ssl_handshake_completed
+        # Warning message updated by Ably — the previous message suggested that
+        # when verify_peer is false, the server certificate would be verified
+        # but not checked against the hostname. This is not true — when
+        # verify_peer is false, the server certificate is not verified at all.
+        unless verify_peer?
+          warn "[WARNING; ably-em-http-request] TLS server certificate validation is disabled (use 'tls: {verify_peer: true}'), see" +
+               " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details" unless parent.connopts.tls.has_key?(:verify_peer)
+          return true
+        end
+
         # It’s not great to have to perform the server certificate verification
         # after the handshake has completed, because it means:
         #
@@ -142,12 +152,6 @@ module EventMachine
         # aided by the intermediate certificates provided by the server.
         unless create_certificate_store.verify(server_certificate, @peer_certificate_chain[0...-1])
           raise OpenSSL::SSL::SSLError.new(%(unable to verify the server certificate for "#{host}"))
-        end
-
-        unless verify_peer?
-          warn "[WARNING; ably-em-http-request] TLS hostname validation is disabled (use 'tls: {verify_peer: true}'), see" +
-               " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details" unless parent.connopts.tls.has_key?(:verify_peer)
-          return true
         end
 
         # Verify that the peer’s certificate matches the hostname.

--- a/lib/em-http/http_connection.rb
+++ b/lib/em-http/http_connection.rb
@@ -144,7 +144,7 @@ module EventMachine
         #
         # (As mentioned above, unless something has gone very wrong, these two
         # certificates should be identical.)
-        unless server_certificate == @peer_certificate_chain.last
+        unless server_certificate.to_der == @peer_certificate_chain.last.to_der
           raise OpenSSL::SSL::SSLError.new(%(Peer certificate sense check failed for "#{host}"));
         end
 

--- a/spec/external_spec.rb
+++ b/spec/external_spec.rb
@@ -1,149 +1,146 @@
 require 'helper'
 
-requires_connection do
+describe EventMachine::AblyHttpRequest::HttpRequest do
 
-  describe EventMachine::AblyHttpRequest::HttpRequest do
-
-    it "should follow redirects on HEAD method (external)" do
-      EventMachine.run {
-        http = EventMachine::AblyHttpRequest::HttpRequest.new('http://www.google.com/').head :redirects => 1
-        http.errback { failed(http) }
-        http.callback {
-          http.response_header.status.should == 200
-          EM.stop
-        }
+  it "should follow redirects on HEAD method (external)" do
+    EventMachine.run {
+      http = EventMachine::AblyHttpRequest::HttpRequest.new('http://www.google.com/').head :redirects => 1
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 200
+        EM.stop
       }
-    end
-
-    it "should follow redirect to https and initiate the handshake" do
-      EventMachine.run {
-        http = EventMachine::AblyHttpRequest::HttpRequest.new('http://github.com/').get :redirects => 5
-
-        http.errback { failed(http) }
-        http.callback {
-          http.response_header.status.should == 200
-          EventMachine.stop
-        }
-      }
-    end
-
-    it "should perform a streaming GET" do
-      EventMachine.run {
-
-        # digg.com uses chunked encoding
-        http = EventMachine::AblyHttpRequest::HttpRequest.new('http://www.httpwatch.com/httpgallery/chunked/').get
-
-        http.errback { failed(http) }
-        http.callback {
-          http.response_header.status.should == 200
-          EventMachine.stop
-        }
-      }
-    end
-
-    it "should handle a 100 continue" do
-      EventMachine.run {
-        # 8.2.3 Use of the 100 (Continue) Status - http://www.ietf.org/rfc/rfc2616.txt
-        #
-        # An origin server SHOULD NOT send a 100 (Continue) response if
-        # the request message does not include an Expect request-header
-        # field with the "100-continue" expectation, and MUST NOT send a
-        # 100 (Continue) response if such a request comes from an HTTP/1.0
-        # (or earlier) client. There is an exception to this rule: for
-        # compatibility with RFC 2068, a server MAY send a 100 (Continue)
-        # status in response to an HTTP/1.1 PUT or POST request that does
-        # not include an Expect request-header field with the "100-
-        # continue" expectation. This exception, the purpose of which is
-        # to minimize any client processing delays associated with an
-        # undeclared wait for 100 (Continue) status, applies only to
-        # HTTP/1.1 requests, and not to requests with any other HTTP-
-        # version value.
-        #
-        # 10.1.1: 100 Continue - http://www.ietf.org/rfc/rfc2068.txt
-        # The client may continue with its request. This interim response is
-        # used to inform the client that the initial part of the request has
-        # been received and has not yet been rejected by the server. The client
-        # SHOULD continue by sending the remainder of the request or, if the
-        # request has already been completed, ignore this response. The server
-        # MUST send a final response after the request has been completed.
-
-        url = 'http://ws.serviceobjects.com/lv/LeadValidation.asmx/ValidateLead_V2'
-        http = EventMachine::AblyHttpRequest::HttpRequest.new(url).post :body => {:name => :test}
-
-        http.errback { failed(http) }
-        http.callback {
-          http.response_header.status.should == 500
-          http.response.should match('Missing')
-          EventMachine.stop
-        }
-      }
-    end
-
-    it "should detect deflate encoding" do
-      EventMachine.run {
-
-        options = {:head => {"accept-encoding" => "deflate"}, :redirects => 5}
-        http = EventMachine::AblyHttpRequest::HttpRequest.new('https://www.bing.com/').get options
-
-        http.errback { failed(http) }
-        http.callback {
-          http.response_header.status.should == 200
-          http.response_header["CONTENT_ENCODING"].should == "deflate"
-
-          EventMachine.stop
-        }
-      }
-    end
-
-    it "should stream chunked gzipped data" do
-      EventMachine.run {
-        options = {:head => {"accept-encoding" => "gzip"}}
-        # GitHub sends chunked gzip, time for a little Inception ;)
-        http = EventMachine::AblyHttpRequest::HttpRequest.new('https://github.com/igrigorik/em-http-request/commits/master').get options
-
-        http.errback { failed(http) }
-        http.callback {
-          http.response_header.status.should == 200
-          http.response_header["CONTENT_ENCODING"].should == "gzip"
-          http.response.should == ''
-
-          EventMachine.stop
-        }
-
-        body = ''
-        http.stream do |chunk|
-          body << chunk
-        end
-      }
-    end
-
-    context "keepalive" do
-      it "should default to non-keepalive" do
-        EventMachine.run {
-          headers = {'If-Modified-Since' => 'Thu, 05 Aug 2010 22:54:44 GMT'}
-          http = EventMachine::AblyHttpRequest::HttpRequest.new('http://www.google.com/images/logos/ps_logo2.png').get :head => headers
-
-          http.errback { fail }
-          start = Time.now.to_i
-          http.callback {
-            (Time.now.to_i - start).should be_within(2).of(0)
-            EventMachine.stop
-          }
-        }
-      end
-
-      it "should work with keep-alive servers" do
-        EventMachine.run {
-          http = EventMachine::AblyHttpRequest::HttpRequest.new('https://github.com/igrigorik/em-http-request').get :keepalive => true
-
-          http.errback { failed(http) }
-          http.callback {
-            http.response_header.status.should == 200
-            EventMachine.stop
-          }
-        }
-      end
-    end
-
+    }
   end
+
+  it "should follow redirect to https and initiate the handshake" do
+    EventMachine.run {
+      http = EventMachine::AblyHttpRequest::HttpRequest.new('http://github.com/').get :redirects => 5
+
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 200
+        EventMachine.stop
+      }
+    }
+  end
+
+  it "should perform a streaming GET" do
+    EventMachine.run {
+
+      # digg.com uses chunked encoding
+      http = EventMachine::AblyHttpRequest::HttpRequest.new('http://www.httpwatch.com/httpgallery/chunked/').get
+
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 200
+        EventMachine.stop
+      }
+    }
+  end
+
+  it "should handle a 100 continue" do
+    EventMachine.run {
+      # 8.2.3 Use of the 100 (Continue) Status - http://www.ietf.org/rfc/rfc2616.txt
+      #
+      # An origin server SHOULD NOT send a 100 (Continue) response if
+      # the request message does not include an Expect request-header
+      # field with the "100-continue" expectation, and MUST NOT send a
+      # 100 (Continue) response if such a request comes from an HTTP/1.0
+      # (or earlier) client. There is an exception to this rule: for
+      # compatibility with RFC 2068, a server MAY send a 100 (Continue)
+      # status in response to an HTTP/1.1 PUT or POST request that does
+      # not include an Expect request-header field with the "100-
+      # continue" expectation. This exception, the purpose of which is
+      # to minimize any client processing delays associated with an
+      # undeclared wait for 100 (Continue) status, applies only to
+      # HTTP/1.1 requests, and not to requests with any other HTTP-
+      # version value.
+      #
+      # 10.1.1: 100 Continue - http://www.ietf.org/rfc/rfc2068.txt
+      # The client may continue with its request. This interim response is
+      # used to inform the client that the initial part of the request has
+      # been received and has not yet been rejected by the server. The client
+      # SHOULD continue by sending the remainder of the request or, if the
+      # request has already been completed, ignore this response. The server
+      # MUST send a final response after the request has been completed.
+
+      url = 'http://ws.serviceobjects.com/lv/LeadValidation.asmx/ValidateLead_V2'
+      http = EventMachine::AblyHttpRequest::HttpRequest.new(url).post :body => {:name => :test}
+
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 500
+        http.response.should match('Missing')
+        EventMachine.stop
+      }
+    }
+  end
+
+  it "should detect deflate encoding" do
+    EventMachine.run {
+
+      options = {:head => {"accept-encoding" => "deflate"}, :redirects => 5}
+      http = EventMachine::AblyHttpRequest::HttpRequest.new('https://www.bing.com/').get options
+
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 200
+        http.response_header["CONTENT_ENCODING"].should == "deflate"
+
+        EventMachine.stop
+      }
+    }
+  end
+
+  it "should stream chunked gzipped data" do
+    EventMachine.run {
+      options = {:head => {"accept-encoding" => "gzip"}}
+      # GitHub sends chunked gzip, time for a little Inception ;)
+      http = EventMachine::AblyHttpRequest::HttpRequest.new('https://github.com/igrigorik/em-http-request/commits/master').get options
+
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 200
+        http.response_header["CONTENT_ENCODING"].should == "gzip"
+        http.response.should == ''
+
+        EventMachine.stop
+      }
+
+      body = ''
+      http.stream do |chunk|
+        body << chunk
+      end
+    }
+  end
+
+  context "keepalive" do
+    it "should default to non-keepalive" do
+      EventMachine.run {
+        headers = {'If-Modified-Since' => 'Thu, 05 Aug 2010 22:54:44 GMT'}
+        http = EventMachine::AblyHttpRequest::HttpRequest.new('http://www.google.com/images/logos/ps_logo2.png').get :head => headers
+
+        http.errback { fail }
+        start = Time.now.to_i
+        http.callback {
+          (Time.now.to_i - start).should be_within(2).of(0)
+          EventMachine.stop
+        }
+      }
+    end
+
+    it "should work with keep-alive servers" do
+      EventMachine.run {
+        http = EventMachine::AblyHttpRequest::HttpRequest.new('https://github.com/igrigorik/em-http-request').get :keepalive => true
+
+        http.errback { failed(http) }
+        http.callback {
+          http.response_header.status.should == 200
+          EventMachine.stop
+        }
+      }
+    end
+  end
+
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -14,10 +14,6 @@ def failed(http = nil)
   http ? fail(http.error) : fail
 end
 
-def requires_connection(&blk)
-  blk.call if system('ping -t1 -c1 google.com 2>&1 > /dev/null')
-end
-
 def requires_port(port, &blk)
   port_open = true
   begin

--- a/spec/pipelining_spec.rb
+++ b/spec/pipelining_spec.rb
@@ -1,66 +1,62 @@
 require 'helper'
 
-requires_connection do
+describe EventMachine::AblyHttpRequest::HttpRequest do
 
-  describe EventMachine::AblyHttpRequest::HttpRequest do
+  it "should perform successful pipelined GETs" do
+    EventMachine.run do
 
-    it "should perform successful pipelined GETs" do
-      EventMachine.run do
+      # Mongrel doesn't support pipelined requests - bah!
+      conn = EventMachine::AblyHttpRequest::HttpRequest.new('http://www.bing.com/')
 
-        # Mongrel doesn't support pipelined requests - bah!
-        conn = EventMachine::AblyHttpRequest::HttpRequest.new('http://www.bing.com/')
+      pipe1 = conn.get :keepalive => true
+      pipe2 = conn.get :path => '/news', :keepalive => true
 
-        pipe1 = conn.get :keepalive => true
-        pipe2 = conn.get :path => '/news', :keepalive => true
+      processed = 0
+      stop = proc { EM.stop if processed == 2}
 
-        processed = 0
-        stop = proc { EM.stop if processed == 2}
+      pipe1.errback { failed(conn) }
+      pipe1.callback {
+        processed += 1
+        pipe1.response_header.status.should == 200
+        stop.call
+      }
 
-        pipe1.errback { failed(conn) }
-        pipe1.callback {
-          processed += 1
-          pipe1.response_header.status.should == 200
-          stop.call
-        }
-
-        pipe2.errback { failed(conn) }
-        pipe2.callback {
-          processed += 1
-          pipe2.response_header.status.should == 200
-          pipe2.response.should match(/html/i)
-          stop.call
-        }
-
-      end
-    end
-
-    it "should perform successful pipelined HEAD requests" do
-      EventMachine.run do
-        conn = EventMachine::AblyHttpRequest::HttpRequest.new('http://www.bing.com/')
-
-        pipe1 = conn.head :keepalive => true
-        pipe2 = conn.head :path => '/news', :keepalive => true
-
-        processed = 0
-        stop = proc { EM.stop if processed == 2}
-
-        pipe1.errback { failed(conn) }
-        pipe1.callback {
-          processed += 1
-          pipe1.response_header.status.should == 200
-          stop.call
-        }
-
-        pipe2.errback { failed(conn) }
-        pipe2.callback {
-          processed += 1
-          pipe2.response_header.status.should == 200
-          stop.call
-        }
-
-      end
+      pipe2.errback { failed(conn) }
+      pipe2.callback {
+        processed += 1
+        pipe2.response_header.status.should == 200
+        pipe2.response.should match(/html/i)
+        stop.call
+      }
 
     end
   end
 
+  it "should perform successful pipelined HEAD requests" do
+    EventMachine.run do
+      conn = EventMachine::AblyHttpRequest::HttpRequest.new('http://www.bing.com/')
+
+      pipe1 = conn.head :keepalive => true
+      pipe2 = conn.head :path => '/news', :keepalive => true
+
+      processed = 0
+      stop = proc { EM.stop if processed == 2}
+
+      pipe1.errback { failed(conn) }
+      pipe1.callback {
+        processed += 1
+        pipe1.response_header.status.should == 200
+        stop.call
+      }
+
+      pipe2.errback { failed(conn) }
+      pipe2.callback {
+        processed += 1
+        pipe2.response_header.status.should == 200
+        stop.call
+      }
+
+    end
+
+  end
 end

--- a/spec/socksify_proxy_spec.rb
+++ b/spec/socksify_proxy_spec.rb
@@ -1,60 +1,56 @@
 require 'helper'
 
-requires_connection do
+requires_port(8080) do
+  describe EventMachine::AblyHttpRequest::HttpRequest do
 
-  requires_port(8080) do
-    describe EventMachine::AblyHttpRequest::HttpRequest do
+    # ssh -D 8080 igvita
+    let(:proxy) { {:proxy => { :host => '127.0.0.1', :port => 8080, :type => :socks5 }} }
 
-      # ssh -D 8080 igvita
-      let(:proxy) { {:proxy => { :host => '127.0.0.1', :port => 8080, :type => :socks5 }} }
+    it "should use SOCKS5 proxy" do
+      EventMachine.run {
+        http = EventMachine::AblyHttpRequest::HttpRequest.new('http://jsonip.com/', proxy).get
 
-      it "should use SOCKS5 proxy" do
-        EventMachine.run {
-          http = EventMachine::AblyHttpRequest::HttpRequest.new('http://jsonip.com/', proxy).get
-
-          http.errback { failed(http) }
-          http.callback {
-            http.response_header.status.should == 200
-            http.response.should match('173.230.151.99')
-            EventMachine.stop
-          }
+        http.errback { failed(http) }
+        http.callback {
+          http.response_header.status.should == 200
+          http.response.should match('173.230.151.99')
+          EventMachine.stop
         }
-      end
+      }
     end
   end
+end
 
-  requires_port(8081) do
-    describe EventMachine::AblyHttpRequest::HttpRequest do
+requires_port(8081) do
+  describe EventMachine::AblyHttpRequest::HttpRequest do
 
-      # brew install tinyproxy
-      let(:http_proxy) { {:proxy => { :host => '127.0.0.1', :port => 8081 }} }
+    # brew install tinyproxy
+    let(:http_proxy) { {:proxy => { :host => '127.0.0.1', :port => 8081 }} }
 
-      it "should use HTTP proxy by default" do
-        EventMachine.run {
-          http = EventMachine::AblyHttpRequest::HttpRequest.new('http://jsonip.com/', http_proxy).get
+    it "should use HTTP proxy by default" do
+      EventMachine.run {
+        http = EventMachine::AblyHttpRequest::HttpRequest.new('http://jsonip.com/', http_proxy).get
 
-          http.errback { failed(http) }
-          http.callback {
-            http.response_header.status.should == 200
-            http.response.should match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)
-            EventMachine.stop
-          }
+        http.errback { failed(http) }
+        http.callback {
+          http.response_header.status.should == 200
+          http.response.should match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)
+          EventMachine.stop
         }
-      end
+      }
+    end
 
-      it "should auto CONNECT via HTTP proxy for HTTPS requests" do
-        EventMachine.run {
-          http = EventMachine::AblyHttpRequest::HttpRequest.new('https://ipjson.herokuapp.com/', http_proxy).get
+    it "should auto CONNECT via HTTP proxy for HTTPS requests" do
+      EventMachine.run {
+        http = EventMachine::AblyHttpRequest::HttpRequest.new('https://ipjson.herokuapp.com/', http_proxy).get
 
-          http.errback { failed(http) }
-          http.callback {
-            http.response_header.status.should == 200
-            http.response.should match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)
-            EventMachine.stop
-          }
+        http.errback { failed(http) }
+        http.callback {
+          http.response_header.status.should == 200
+          http.response.should match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/)
+          EventMachine.stop
         }
-      end
+      }
     end
   end
-
 end

--- a/spec/ssl_spec.rb
+++ b/spec/ssl_spec.rb
@@ -17,7 +17,7 @@ requires_connection do
 
     describe "TLS hostname verification" do
       before do
-        @cve_warning = "[WARNING; ably-em-http-request] TLS hostname validation is disabled (use 'tls: {verify_peer: true}'), see" +
+        @cve_warning = "[WARNING; ably-em-http-request] TLS server certificate validation is disabled (use 'tls: {verify_peer: true}'), see" +
                        " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details"
         @orig_stderr = $stderr
         $stderr = StringIO.new

--- a/spec/ssl_spec.rb
+++ b/spec/ssl_spec.rb
@@ -1,71 +1,67 @@
 require 'helper'
 
-requires_connection do
+describe EventMachine::AblyHttpRequest::HttpRequest do
+  it "should initiate SSL/TLS on HTTPS connections" do
+    EventMachine.run {
+      http = EventMachine::AblyHttpRequest::HttpRequest.new('https://mail.google.com:443/mail/').get
 
-  describe EventMachine::AblyHttpRequest::HttpRequest do
-    it "should initiate SSL/TLS on HTTPS connections" do
+      http.errback { failed(http) }
+      http.callback {
+        http.response_header.status.should == 301
+        EventMachine.stop
+      }
+    }
+  end
+
+  describe "TLS hostname verification" do
+    before do
+      @cve_warning = "[WARNING; ably-em-http-request] TLS server certificate validation is disabled (use 'tls: {verify_peer: true}'), see" +
+                     " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details"
+      @orig_stderr = $stderr
+      $stderr = StringIO.new
+    end
+
+    after do
+      $stderr = @orig_stderr
+    end
+
+    it "should not warn if verify_peer is specified" do
       EventMachine.run {
-        http = EventMachine::AblyHttpRequest::HttpRequest.new('https://mail.google.com:443/mail/').get
+        http = EventMachine::AblyHttpRequest::HttpRequest.new('https://mail.google.com:443/mail', {tls: {verify_peer: false}}).get
 
-        http.errback { failed(http) }
         http.callback {
-          http.response_header.status.should == 301
+          $stderr.rewind
+          $stderr.string.chomp.should_not eq(@cve_warning)
+
           EventMachine.stop
         }
       }
     end
 
-    describe "TLS hostname verification" do
-      before do
-        @cve_warning = "[WARNING; ably-em-http-request] TLS server certificate validation is disabled (use 'tls: {verify_peer: true}'), see" +
-                       " CVE-2020-13482 and https://github.com/igrigorik/em-http-request/issues/339 for details"
-        @orig_stderr = $stderr
-        $stderr = StringIO.new
-      end
+    it "should not warn if verify_peer is true" do
+      EventMachine.run {
+        http = EventMachine::AblyHttpRequest::HttpRequest.new('https://mail.google.com:443/mail', {tls: {verify_peer: true}}).get
 
-      after do
-        $stderr = @orig_stderr
-      end
+        http.callback {
+          $stderr.rewind
+          $stderr.string.chomp.should_not eq(@cve_warning)
 
-      it "should not warn if verify_peer is specified" do
-        EventMachine.run {
-          http = EventMachine::AblyHttpRequest::HttpRequest.new('https://mail.google.com:443/mail', {tls: {verify_peer: false}}).get
-
-          http.callback {
-            $stderr.rewind
-            $stderr.string.chomp.should_not eq(@cve_warning)
-
-            EventMachine.stop
-          }
+          EventMachine.stop
         }
-      end
+      }
+    end
 
-      it "should not warn if verify_peer is true" do
-        EventMachine.run {
-          http = EventMachine::AblyHttpRequest::HttpRequest.new('https://mail.google.com:443/mail', {tls: {verify_peer: true}}).get
+    it "should warn if verify_peer is unspecified" do
+      EventMachine.run {
+        http = EventMachine::AblyHttpRequest::HttpRequest.new('https://mail.google.com:443/mail').get
 
-          http.callback {
-            $stderr.rewind
-            $stderr.string.chomp.should_not eq(@cve_warning)
+        http.callback {
+          $stderr.rewind
+          $stderr.string.chomp.should eq(@cve_warning)
 
-            EventMachine.stop
-          }
+          EventMachine.stop
         }
-      end
-
-      it "should warn if verify_peer is unspecified" do
-        EventMachine.run {
-          http = EventMachine::AblyHttpRequest::HttpRequest.new('https://mail.google.com:443/mail').get
-
-          http.callback {
-            $stderr.rewind
-            $stderr.string.chomp.should eq(@cve_warning)
-
-            EventMachine.stop
-          }
-        }
-      end
+      }
     end
   end
-
 end


### PR DESCRIPTION
Fixes a couple of issues I introduced in #2. I didn’t notice these issues because the tests that they broke weren’t being run in CI, so I’ve sorted that out too. See commit messages for more details.